### PR TITLE
Fixing Grade rounding

### DIFF
--- a/student-course-summary/query.sql
+++ b/student-course-summary/query.sql
@@ -12,7 +12,7 @@ select
     lca.last_course_access,
     round(zeroifnull(ls.submission_count),0) as submission_count,
     ls.last_submission,
-    round(zeroifnull(gr.total_grade),0) as  total_grade
+    round(zeroifnull(gr.total_grade),2) as  total_grade
 from cdm_lms.person lp -- for Course attributes
 inner join cdm_lms.person_course lpc -- for User-Course mapping
     on lpc.person_id = lp.id


### PR DESCRIPTION
Grade is decimal but was rounded to 0 places, so could only be 1 or 0. Changed to 2 decimal places so it will round to the nearest whole percentage point (e.g. 0.67 for 67%).